### PR TITLE
Added retry in case of PIPE_SIZE_MISMATCH

### DIFF
--- a/v3/data/job/mget/mget.js
+++ b/v3/data/job/mget/mget.js
@@ -119,7 +119,7 @@ class MGet {
 
           if (segment) {
             const p = position - 1;
-            let retryCount = 3;
+            let retryCount = 10;
             while (retryCount > 0) {
               try {
                 let sm = { ...segment };

--- a/v3/data/job/mget/mget.js
+++ b/v3/data/job/mget/mget.js
@@ -118,22 +118,33 @@ class MGet {
           position += 1;
 
           if (segment) {
-            try {
-              const p = position - 1;
-
-              await this.prepare(segment, p);
-              await this.pipe(segment, params, p, () => {
-                // start a new segment if we have a free thread and there are leftover segments
-                if (this.number() && segments.length) {
-                  start();
+            const p = position - 1;
+            let retryCount = 3;
+            while (retryCount > 0) {
+              try {
+                let sm = { ...segment };
+                await this.prepare(sm, p);
+                await this.pipe(sm, params, p, () => {
+                  // start a new segment if we have a free thread and there are leftover segments
+                  if (this.number() && segments.length) {
+                    start();
+                  }
+                });
+                await this.flush(sm, p);
+                break;
+              }
+              catch (e) {
+                if (e?.message === 'PIPE_SIZE_MISMATCH') {
+                  console.error(e.message, 'at position:', position, '. Download it again!', retryCount, 'retries left');
+                  retryCount -= 1;
                 }
-              });
-              await this.flush(segment, p);
-              start();
+                if (retryCount === 0) {
+                  reject(e);
+                  break;
+                }
+              }
             }
-            catch (e) {
-              reject(e);
-            }
+            start();
           }
           else {
             if (this.actives === 0) {


### PR DESCRIPTION
Fixes https://github.com/chandler-stimson/live-stream-downloader/issues/142 and helps with https://github.com/chandler-stimson/live-stream-downloader/issues/37
Credit to @xd1gital

This addon has become nearly unusable due to constant occurrence of `PIPE_SIZE_MISMATCH` which will abort any download immediately on the first misaligned chunk. Damaged chunks can have many reasons including unstable connection, high machine load, laggy backend etc.
In my testing it was impossible to download a 5GB example stream within 15 tries. With the fix it went through on the first try, all broken chunks were successfully redownloaded on the first retry, 
<img width="1688" height="519" alt="grafik" src="https://github.com/user-attachments/assets/4bd75bc8-d741-4c45-91de-d9cffee6f87c" />


Oh and I could not pull this repo on windows due to an illegal character in a filename, might want to correct that @chandler-stimson 
<img width="788" height="359" alt="grafik" src="https://github.com/user-attachments/assets/95191ac7-c327-44f1-b769-98e5a2cbb1f7" />